### PR TITLE
gulp-istanbul and should must be devDependencies (instead of dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
   },
   "dependencies": {
     "debug": "^2.0.0",
-    "gulp-istanbul": "^0.10.0",
     "js-combinatorics": "^0.5.0",
-    "lodash": "^4.17.4",
-    "should": "4.0.4"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "chai": "^1.9.1",
@@ -32,11 +30,13 @@
     "coffee-script": "^1.7.1",
     "gulp": "^3.8.6",
     "gulp-coffee": "^2.1.1",
+    "gulp-istanbul": "^0.10.0",
     "gulp-mocha": "^0.5.1",
     "gulp-util": "^2.2.20",
     "mocha": "^1.18.2",
     "sinon": "^1.9.1",
-    "sinon-chai": "^2.5.0"
+    "sinon-chai": "^2.5.0",
+    "should": "4.0.4"
   },
   "engines": {
     "node": ">=0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calc-box",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Awesome module",
   "keywords": [],
   "homepage": "https://github.com/tokyootakumode/calc-box",


### PR DESCRIPTION
`gulp-istanbul` will install electron when you do `npm install --production`. It is an unwanted behavior.
And `should` is unnecessary for production install too.